### PR TITLE
Parent and child sets and indexes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.3.0
 Author: person("Magnus", "Furugård", email = "magnus.furugard@gmail.com", role = c("aut", "cre"))
 Maintainer: Magnus Furugård <magnus.furugard@gmail.com>
 Description: A reticulate-based interface to the Python module Featuretools.
-License: MIT + file LICENCE
+License: MIT + file LICENSE
 URL: https://github.com/magnusfurugard/featuretoolsR
 BugReports: https://github.com/magnusfurugard/featuretoolsR/issues
 Depends: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: featuretoolsR
 Type: Package
 Title: Interact with the Python module Featuretools through R
-Version: 0.3.0
+Version: 0.4.0
 Author: person("Magnus", "Furugård", email = "magnus.furugard@gmail.com", role = c("aut", "cre"))
 Maintainer: Magnus Furugård <magnus.furugard@gmail.com>
 Description: A reticulate-based interface to the Python module Featuretools.

--- a/R/add_relationship.R
+++ b/R/add_relationship.R
@@ -5,7 +5,8 @@
 #' @param entityset The entityset to modify.
 #' @param parent_set The name of the parent set.
 #' @param child_set The name of the child set.
-#' @param idx The variable  `parent_set` and `child_set` have in common.
+#' @param parent_idx The index variable of the `parent_set`.
+#' @param child_idx The index variable of the `child_set`.
 #' @return A modified entityset.
 #'
 #' @examples
@@ -17,12 +18,18 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
+#'   add_relationship(
+#'     parent_set = "set_1",
+#'     child_set = "set_2",
+#'     parent_idx = "key",
+#'     child_idx = "key"
+#'   )
 add_relationship <- function(
   entityset,
   parent_set,
   child_set,
-  idx
+  parent_idx,
+  child_idx
 ) {
   # Find indexes for entites and variables inside entitysets
   es_names <- purrr::map_dfr(lapply(
@@ -45,11 +52,15 @@ add_relationship <- function(
 
   entity_parent_set_pos <- es_names$entity_idx[es_names$entity_name == parent_set][[1]]
   entity_child_set_pos <- es_names$entity_idx[es_names$entity_name == child_set][[1]]
-  index_parent_set_pos <- es_names$variable_idx[es_names$variable_name == idx & es_names$entity_name == parent_set]
-  index_child_set_pos <- es_names$variable_idx[es_names$variable_name == idx & es_names$entity_name == child_set]
+  index_parent_set_pos <- es_names$variable_idx[es_names$variable_name == parent_idx & es_names$entity_name == parent_set]
+  index_child_set_pos <- es_names$variable_idx[es_names$variable_name == child_idx & es_names$entity_name == child_set]
 
-  if (length(index_parent_set_pos) == 0 || length(index_child_set_pos) == 0) {
-    stop("Couldn't find index column `", idx, "` in `", parent_set, "` or `", child_set, "`")
+  if (length(index_parent_set_pos) == 0) {
+    stop("Couldn't find index column `", parent_idx, "` in `", parent_set, "`")
+  }
+
+  if (length(index_child_set_pos) == 0) {
+    stop("Couldn't find index column `", child_idx, "` in `", child_set, "`")
   }
 
   # Construct new relationship

--- a/R/add_relationship.R
+++ b/R/add_relationship.R
@@ -3,9 +3,9 @@
 #' @export
 #'
 #' @param entityset The entityset to modify.
-#' @param set1 The name of the first entity to link.
-#' @param set2 The name of the second entity to link.
-#' @param idx The variable  `set1` and `set2` have in common.
+#' @param parent_set The name of the parent set.
+#' @param child_set The name of the child set.
+#' @param idx The variable  `parent_set` and `child_set` have in common.
 #' @return A modified entityset.
 #'
 #' @examples
@@ -17,11 +17,11 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(set1 = "set_1", set2 = "set_2", idx = "key")
+#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
 add_relationship <- function(
   entityset,
-  set1,
-  set2,
+  parent_set,
+  child_set,
   idx
 ) {
   # Find indexes for entites and variables inside entitysets
@@ -43,19 +43,19 @@ add_relationship <- function(
     }
   ), c)
 
-  entity_set1_pos <- es_names$entity_idx[es_names$entity_name == set1][[1]]
-  entity_set2_pos <- es_names$entity_idx[es_names$entity_name == set2][[1]]
-  index_set1_pos <- es_names$variable_idx[es_names$variable_name == idx & es_names$entity_name == set1]
-  index_set2_pos <- es_names$variable_idx[es_names$variable_name == idx & es_names$entity_name == set2]
+  entity_parent_set_pos <- es_names$entity_idx[es_names$entity_name == parent_set][[1]]
+  entity_child_set_pos <- es_names$entity_idx[es_names$entity_name == child_set][[1]]
+  index_parent_set_pos <- es_names$variable_idx[es_names$variable_name == idx & es_names$entity_name == parent_set]
+  index_child_set_pos <- es_names$variable_idx[es_names$variable_name == idx & es_names$entity_name == child_set]
 
-  if (length(index_set1_pos) == 0 || length(index_set2_pos) == 0) {
-    stop("Couldn't find index column `", idx, "` in `", set1, "` or `", set2, "`")
+  if (length(index_parent_set_pos) == 0 || length(index_child_set_pos) == 0) {
+    stop("Couldn't find index column `", idx, "` in `", parent_set, "` or `", child_set, "`")
   }
 
   # Construct new relationship
   rel <- .ft$Relationship(
-    entityset$entities[[entity_set1_pos]]$variables[[index_set1_pos]],
-    entityset$entities[[entity_set2_pos]]$variables[[index_set2_pos]]
+    entityset$entities[[entity_parent_set_pos]]$variables[[index_parent_set_pos]],
+    entityset$entities[[entity_child_set_pos]]$variables[[index_child_set_pos]]
   )
 
   # Add relationship to entityset

--- a/R/calculate_feature_matrix.R
+++ b/R/calculate_feature_matrix.R
@@ -19,7 +19,12 @@
 #' # Create features and save them
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
+#'   add_relationship(
+#'     parent_set = "set_1",
+#'     child_set = "set_2",
+#'     parent_idx = "key",
+#'     child_idx = "key"
+#'   ) %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features() %>%
 #'   save_features(filename = "some.features")
@@ -27,7 +32,12 @@
 #' # Re-create entityset, but rather than dfs use calcualte_feature_matrix.
 #' es <- as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
+#'   add_relationship(
+#'     parent_set = "set_1",
+#'     child_set = "set_2",
+#'     parent_idx = "key",
+#'     child_idx = "key"
+#'   )
 #' calculate_feature_matrix(entityset = es, features = load_features("some.features"))
 #'
 calculate_feature_matrix <- function(

--- a/R/calculate_feature_matrix.R
+++ b/R/calculate_feature_matrix.R
@@ -19,7 +19,7 @@
 #' # Create features and save them
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") %>%
+#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features() %>%
 #'   save_features(filename = "some.features")
@@ -27,7 +27,7 @@
 #' # Re-create entityset, but rather than dfs use calcualte_feature_matrix.
 #' es <- as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(set1 = "set_1", set2 = "set_2", idx = "key")
+#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
 #' calculate_feature_matrix(entityset = es, features = load_features("some.features"))
 #'
 calculate_feature_matrix <- function(

--- a/R/extract_features.R
+++ b/R/extract_features.R
@@ -17,7 +17,12 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
+#'   add_relationship(
+#'     parent_set = "set_1",
+#'     child_set = "set_2",
+#'     parent_idx = "key",
+#'     child_idx = "key"
+#'   ) %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features()
 #'

--- a/R/extract_features.R
+++ b/R/extract_features.R
@@ -17,7 +17,7 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") %>%
+#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features()
 #'

--- a/R/load_features.R
+++ b/R/load_features.R
@@ -15,7 +15,12 @@
 #' # Use dfs to create features
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
+#'   add_relationship(
+#'     parent_set = "set_1",
+#'     child_set = "set_2",
+#'     parent_idx = "key",
+#'     child_idx = "key"
+#'   ) %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features() %>%
 #'   save_features(filename = "some.features")

--- a/R/load_features.R
+++ b/R/load_features.R
@@ -15,7 +15,7 @@
 #' # Use dfs to create features
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") %>%
+#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features() %>%
 #'   save_features(filename = "some.features")

--- a/R/save_features.R
+++ b/R/save_features.R
@@ -18,7 +18,7 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") %>%
+#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features() %>%
 #'   save_features(filename = "some.features")

--- a/R/save_features.R
+++ b/R/save_features.R
@@ -18,7 +18,12 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
+#'   add_relationship(
+#'     parent_set = "set_1",
+#'     child_set = "set_2",
+#'     parent_idx = "key",
+#'     child_idx = "key"
+#'   ) %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   extract_features() %>%
 #'   save_features(filename = "some.features")

--- a/R/tidy_feature_matrix.R
+++ b/R/tidy_feature_matrix.R
@@ -21,7 +21,7 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") %>%
+#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   tidy_feature_matrix(remove_nzv = TRUE, nan_is_na = TRUE)
 tidy_feature_matrix <- function(

--- a/R/tidy_feature_matrix.R
+++ b/R/tidy_feature_matrix.R
@@ -21,7 +21,12 @@
 #'
 #' as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") %>%
 #'   add_entity(entity_id = "set_2", df = set_2, index = "key") %>%
-#'   add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") %>%
+#'   add_relationship(
+#'     parent_set = "set_1",
+#'     child_set = "set_2",
+#'     parent_idx = "key",
+#'     child_idx = "key"
+#'   ) %>%
 #'   dfs(target_entity = "set_1", trans_primitives = c("and")) %>%
 #'   tidy_feature_matrix(remove_nzv = TRUE, nan_is_na = TRUE)
 tidy_feature_matrix <- function(

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ With relational data, it's useful to define a relationship between two or more e
 ```
 es <- es %>%
   add_relationship(
-    set1 = "set_1", 
-    set2 = "set_2", 
+    parent_set = "set_1", 
+    child_set = "set_2", 
     idx = "key"
   )
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ es <- es %>%
   add_relationship(
     parent_set = "set_1", 
     child_set = "set_2", 
-    idx = "key"
+    parent_idx = "key", 
+    child_idx = "key"
   )
 ```
 

--- a/man/add_relationship.Rd
+++ b/man/add_relationship.Rd
@@ -4,7 +4,7 @@
 \alias{add_relationship}
 \title{Add a relationship to an entityset}
 \usage{
-add_relationship(entityset, parent_set, child_set, idx)
+add_relationship(entityset, parent_set, child_set, parent_idx, child_idx)
 }
 \arguments{
 \item{entityset}{The entityset to modify.}
@@ -13,7 +13,9 @@ add_relationship(entityset, parent_set, child_set, idx)
 
 \item{child_set}{The name of the child set.}
 
-\item{idx}{The variable  `parent_set` and `child_set` have in common.}
+\item{parent_idx}{The index variable of the `parent_set`.}
+
+\item{child_idx}{The index variable of the `child_set`.}
 }
 \value{
 A modified entityset.
@@ -30,5 +32,10 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
+  add_relationship(
+    parent_set = "set_1",
+    child_set = "set_2",
+    parent_idx = "key",
+    child_idx = "key"
+  )
 }

--- a/man/add_relationship.Rd
+++ b/man/add_relationship.Rd
@@ -4,16 +4,16 @@
 \alias{add_relationship}
 \title{Add a relationship to an entityset}
 \usage{
-add_relationship(entityset, set1, set2, idx)
+add_relationship(entityset, parent_set, child_set, idx)
 }
 \arguments{
 \item{entityset}{The entityset to modify.}
 
-\item{set1}{The name of the first entity to link.}
+\item{parent_set}{The name of the parent set.}
 
-\item{set2}{The name of the second entity to link.}
+\item{child_set}{The name of the child set.}
 
-\item{idx}{The variable  `set1` and `set2` have in common.}
+\item{idx}{The variable  `parent_set` and `child_set` have in common.}
 }
 \value{
 A modified entityset.
@@ -30,5 +30,5 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(set1 = "set_1", set2 = "set_2", idx = "key")
+  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
 }

--- a/man/calculate_feature_matrix.Rd
+++ b/man/calculate_feature_matrix.Rd
@@ -31,7 +31,12 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 # Create features and save them
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
+  add_relationship(
+    parent_set = "set_1",
+    child_set = "set_2",
+    parent_idx = "key",
+    child_idx = "key"
+  ) \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features() \%>\%
   save_features(filename = "some.features")
@@ -39,7 +44,12 @@ as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
 # Re-create entityset, but rather than dfs use calcualte_feature_matrix.
 es <- as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
+  add_relationship(
+    parent_set = "set_1",
+    child_set = "set_2",
+    parent_idx = "key",
+    child_idx = "key"
+  )
 calculate_feature_matrix(entityset = es, features = load_features("some.features"))
 
 }

--- a/man/calculate_feature_matrix.Rd
+++ b/man/calculate_feature_matrix.Rd
@@ -31,7 +31,7 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 # Create features and save them
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") \%>\%
+  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features() \%>\%
   save_features(filename = "some.features")
@@ -39,7 +39,7 @@ as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
 # Re-create entityset, but rather than dfs use calcualte_feature_matrix.
 es <- as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(set1 = "set_1", set2 = "set_2", idx = "key")
+  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key")
 calculate_feature_matrix(entityset = es, features = load_features("some.features"))
 
 }

--- a/man/extract_features.Rd
+++ b/man/extract_features.Rd
@@ -24,7 +24,7 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") \%>\%
+  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features()
 

--- a/man/extract_features.Rd
+++ b/man/extract_features.Rd
@@ -24,7 +24,12 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
+  add_relationship(
+    parent_set = "set_1",
+    child_set = "set_2",
+    parent_idx = "key",
+    child_idx = "key"
+  ) \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features()
 

--- a/man/load_features.Rd
+++ b/man/load_features.Rd
@@ -23,7 +23,12 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 # Use dfs to create features
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
+  add_relationship(
+    parent_set = "set_1",
+    child_set = "set_2",
+    parent_idx = "key",
+    child_idx = "key"
+  ) \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features() \%>\%
   save_features(filename = "some.features")

--- a/man/load_features.Rd
+++ b/man/load_features.Rd
@@ -23,7 +23,7 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 # Use dfs to create features
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") \%>\%
+  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features() \%>\%
   save_features(filename = "some.features")

--- a/man/save_features.Rd
+++ b/man/save_features.Rd
@@ -25,7 +25,7 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") \%>\%
+  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features() \%>\%
   save_features(filename = "some.features")

--- a/man/save_features.Rd
+++ b/man/save_features.Rd
@@ -25,7 +25,12 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
+  add_relationship(
+    parent_set = "set_1",
+    child_set = "set_2",
+    parent_idx = "key",
+    child_idx = "key"
+  ) \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   extract_features() \%>\%
   save_features(filename = "some.features")

--- a/man/tidy_feature_matrix.Rd
+++ b/man/tidy_feature_matrix.Rd
@@ -31,7 +31,12 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
+  add_relationship(
+    parent_set = "set_1",
+    child_set = "set_2",
+    parent_idx = "key",
+    child_idx = "key"
+  ) \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   tidy_feature_matrix(remove_nzv = TRUE, nan_is_na = TRUE)
 }

--- a/man/tidy_feature_matrix.Rd
+++ b/man/tidy_feature_matrix.Rd
@@ -31,7 +31,7 @@ set_2 <- data.frame(key = 1:100, value = sample(LETTERS, 100, TRUE))
 
 as_entityset(set_1, index = "key", entity_id = "set_1", id = "demo") \%>\%
   add_entity(entity_id = "set_2", df = set_2, index = "key") \%>\%
-  add_relationship(set1 = "set_1", set2 = "set_2", idx = "key") \%>\%
+  add_relationship(parent_set = "set_1", child_set = "set_2", idx = "key") \%>\%
   dfs(target_entity = "set_1", trans_primitives = c("and")) \%>\%
   tidy_feature_matrix(remove_nzv = TRUE, nan_is_na = TRUE)
 }


### PR DESCRIPTION
* Sets are now named `parent_set` and `child_set` as opposed to `set1` and `set2`.
* Sets can now have different index variables, as these are specified explicitly through `parent_idx` or `child_idx`

This resolves #8.