### PR TITLE
cran-patches-1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,13 @@
 Package: featuretoolsR
 Type: Package
 Title: Interact with the Python Module Featuretools Through R
-Version: 0.4.1
-Author: person("Magnus", "Furugård", email = "magnus.furugard@gmail.com", role = c("aut", "cre"))
-Author@R: person("Magnus", "Furugård", email = "magnus.furugard@gmail.com", role = c("aut", "cre"))
+Version: 0.4.2
+Authors@R: person("Magnus", "Furugård", email = "magnus.furugard@gmail.com", role = c("aut", "cre"))
 Maintainer: Magnus Furugård <magnus.furugard@gmail.com>
-Description: A reticulate-based interface to the Python module Featuretools.
+Description: A 'reticulate'-based interface to the Python module 'Featuretools'.
+  The package grants functionality to interact with Pythons 'Featuretools' module through R, which
+  allows for automated feature engineering on any data frame. Valid features and new data sets can after
+  feature synthesis easily be extracted.
 License: MIT + file LICENSE
 URL: https://github.com/magnusfurugard/featuretoolsR
 BugReports: https://github.com/magnusfurugard/featuretoolsR/issues

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,2 @@
-MIT License
-
-Copyright (c) 2019 Magnus Furugård
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+YEAR: 2019
+COPYRIGHT HOLDER: Magnus Furugård

--- a/R/tidy_feature_matrix.R
+++ b/R/tidy_feature_matrix.R
@@ -47,7 +47,6 @@ tidy_feature_matrix <- function(
   # Process `nondupe` according to user defined parameters.
   ## Remove near zero variance
   if(remove_nzv) {
-    cat("Removing near zero variance variables\n")
     nzvs <- purrr::map_dfr(
       lapply(
         X = names(nondupe),
@@ -64,7 +63,6 @@ tidy_feature_matrix <- function(
 
   ## Replace all `NaN` with `NA`
   if(nan_is_na) {
-    cat("Changing all `NaN` to `NA`\n")
     for (colname in names(nondupe)) {
       nondupe[, colname][[1]][is.nan(nondupe[, colname][[1]])] <- NA
     }
@@ -72,7 +70,6 @@ tidy_feature_matrix <- function(
 
   ## Make variable names more R-friendly
   if(clean_names) {
-    cat("Creating R-friendly variable names\n")
     n <- tolower(names(nondupe))
     tn <- gsub("[^A-z0-9]", "_", n)
     tn <- gsub("(_+?$)|(__+?)", "", tn)


### PR DESCRIPTION
After feedback from CRAN:
* Updated license to be the CRAN version of MIT.
* Updated package description.
* Removed typo `Author@R` (--> `Authors@R`)

General:
* Removed verbosity from `tidy_feature_matrix`.